### PR TITLE
fix #27

### DIFF
--- a/frontend/src/components/inPageNav/inPageNav.css
+++ b/frontend/src/components/inPageNav/inPageNav.css
@@ -13,6 +13,7 @@
     position: absolute;
     top: 490px;
     width: 100%;
+    height: 40px;
     margin-left: 0;
     margin-right: 0;
 }


### PR DESCRIPTION
Text links are unclickable because the carousel indicator height. Change it to be exactly 40px.