### PR TITLE
remove non-indicator separator

### DIFF
--- a/frontend/src/components/inPageNav/inPageNav.css
+++ b/frontend/src/components/inPageNav/inPageNav.css
@@ -11,7 +11,7 @@
 
 .carousel-indicators {
     position: absolute;
-    top: 490px;
+    top: 550px;
     width: 100%;
     height: 40px;
     margin-left: 0;
@@ -36,4 +36,5 @@
 
 .carousel-text {
     padding: 2rem;
+    margin-top: 5rem;
 }

--- a/frontend/src/components/inPageNav/inPageNav.tsx
+++ b/frontend/src/components/inPageNav/inPageNav.tsx
@@ -49,7 +49,6 @@ export default class InPageNav extends Component<InPageNavProps, InPageNavState>
                         return (
                             <Carousel.Item>
                                 {Object(obj)["buttonContent"]}
-                                <div className="separator"/>
                                 <div className="carousel-text">
                                     {Object(obj)["page"]}
                                 </div>


### PR DESCRIPTION
Looks like this on master 
![image](https://user-images.githubusercontent.com/6146988/103144958-fb736c00-46e6-11eb-83fe-57bd1b83b4de.png)

Removes the static separator and do some CSS to make sure the separator doesn't cut into the text and image.